### PR TITLE
Restrict deployment to main branch only

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,8 +3,6 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
 
 permissions:
   contents: read
@@ -49,6 +47,7 @@ jobs:
         path: prompt-insights/build
 
   deploy:
+    if: github.ref == 'refs/heads/main'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
- Remove pull_request trigger to prevent deployment from feature branches
- Add condition to deploy job to only run on main branch
- This prevents environment protection rule violations

🤖 Generated with [Claude Code](https://claude.ai/code)